### PR TITLE
fix bug #70

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,12 @@
 {
-  "name": "theme-Joe3",
+  "name": "halo-theme-joe3.0",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "halo-theme-joe3.0",
+      "version": "1.0.8",
       "devDependencies": {
         "uglify-js": "^3.17.4"
       }

--- a/templates/modules/macro/tail.html
+++ b/templates/modules/macro/tail.html
@@ -34,7 +34,7 @@
     <th:block th:if="${htmlType == 'post'} or ${htmlType == 'journals'} or ${htmlType == 'sheet'}">
         <script th:src="@{/assets/lib/clipboard/clipboard.min.js}"></script>
     </th:block>
-    <th:block th:if="${theme.config.custom.favicon == true && theme.config.custom.favicon != null && theme.config.custom.favicon != ''}">
+    <th:block th:if="${theme.config.custom.favicon != null && theme.config.custom.favicon != ''}">
         <script th:src="@{/assets/lib/favico/favico.min.js}"></script>
     </th:block>
     <th:block th:if="${htmlType == 'post'}">


### PR DESCRIPTION
${theme.config.custom.favicon}输出的是图片的相对路径，之前代码if表达式中判断它是否等于true一直是不成立的导致favico.min.js一直是没有引进去的。