### PR TITLE
fix:许可协议链接404和多余的>符号

### DIFF
--- a/templates/modules/macro/post_copyright.html
+++ b/templates/modules/macro/post_copyright.html
@@ -37,7 +37,7 @@
         [[${theme.config.post.passage_rights_content}]]
         </th:block>
           <th:block th:if="${theme.config.post.passage_rights_content == ''} or ${theme.config.post.passage_rights_content == null}">
-        本文使用《<a class="link" href="//creativecommons.org/licenses/by-nc-sa/4.0/deed.zh" target="_blank" rel="noopener noreferrer nofollow">署名-非商业性使用-相同方式共享 4.0 国际 (CC BY-NC-SA 4.0)</a>》协议授权
+        本文使用《<a class="link" href="//creativecommons.org/licenses/by-nc-sa/4.0/deed.zh-hans" target="_blank" rel="noopener noreferrer nofollow">署名-非商业性使用-相同方式共享 4.0 国际 (CC BY-NC-SA 4.0)</a>》协议授权
           </th:block>
         </span>
       </div>

--- a/templates/modules/macro/post_copyright.html
+++ b/templates/modules/macro/post_copyright.html
@@ -38,7 +38,7 @@
         </th:block>
           <th:block th:if="${theme.config.post.passage_rights_content == ''} or ${theme.config.post.passage_rights_content == null}">
         本文使用《<a class="link" href="//creativecommons.org/licenses/by-nc-sa/4.0/deed.zh" target="_blank" rel="noopener noreferrer nofollow">署名-非商业性使用-相同方式共享 4.0 国际 (CC BY-NC-SA 4.0)</a>》协议授权
-          </th:block>>
+          </th:block>
         </span>
       </div>
     </div>


### PR DESCRIPTION
1. 许可协议链接现在是404，因此更换为最新链接
![image](https://github.com/jiewenhuang/halo-theme-joe3.0/assets/22993852/9301518e-4f37-4fb0-8081-9cb7388b2d31)

2.post_copyright.html会多一个 > 符号
![image](https://github.com/jiewenhuang/halo-theme-joe3.0/assets/22993852/bc549424-63b5-4c63-ba91-2ba4b5cfbf7d)
