### PR TITLE
fix bug #138

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -2392,6 +2392,7 @@ spec:
               label: 否
         - $formkit: select
           name: driven_by
+          id: driven_by
           label: 云服务提供商
           value: "none"
           help: "配置本站点由xxx云提供云服务"
@@ -2414,6 +2415,13 @@ spec:
               label: 金山云
             - value: custom
               label: 自定义
+        - $formkit: code
+          if: "$get(driven_by).value === 'custom'"
+          name: driven_custom
+          label: 自定义提供商
+          help: "配置自定义服务提供商，此处可填写html代码"
+          value: ""
+          language: html
         - $formkit: radio
           name: enable_rss
           label: 展示 RSS

--- a/templates/modules/common/footer.html
+++ b/templates/modules/common/footer.html
@@ -72,6 +72,9 @@
           </a>提供云服务
         </p>
       </th:block>
+      <th:block th:if="${theme.config.footer.driven_by == 'custom'}">
+        <p class="site_driven" th:utext="${theme.config.footer.driven_custom}"></p>
+      </th:block>
 
 
     </th:block>


### PR DESCRIPTION
修复了【页脚】选项卡中无法【自定义云服务提供商】（没有输入框）的问题

# FIX ISSUE

#138

# 做了什么

- 为driven_by设置字段添加了id
- 添加了driven_custom设置项
- footer模板添加custom相应的渲染