### PR TITLE
fix: correct display issue for post count in tag list

### DIFF
--- a/templates/archives.html
+++ b/templates/archives.html
@@ -21,7 +21,7 @@
                 <div class="joe_archives-title"><i class="joe-font joe-icon-fenlei"></i>分类</div>
                 <ul class="joe_category-list" th:with="categories = ${categoryFinder.listAll()}">
                   <li class="item" th:each="category : ${categories}">
-                    <a class="link" th:href="@{${category.status.permalink}}" th:title="${category.spec.displayName}"><span th:title="${category.spec.displayName}">[[${category.spec.displayName}]]</span><em>[[${category.status.postCount}]]</em></a>
+                    <a class="link" th:href="@{${category.status.permalink}}" th:title="${category.spec.displayName}"><span th:title="${category.spec.displayName}">[[${category.spec.displayName}]]</span><em th:text="${category.status.visiblePostCount ?: 0}"></em></a>
                   </li>
                 </ul>
               </div>

--- a/templates/modules/macro/post_num.html
+++ b/templates/modules/macro/post_num.html
@@ -2,10 +2,10 @@
 <html lang="en" xmlns:th="https://www.thymeleaf.org">
 <th:block th:fragment="post_num">
   <th:block th:if="${htmlType == 'tags'}">
-    <em class="post-nums">[[${tag.status.postCount +'篇'}]]</em>
+    <em class="post-nums" th:text="|${tag.status.visiblePostCount ?: 0 }篇|"></em>
   </th:block>
   <th:block th:if="${htmlType == 'categories'}">
-    <em class="post-nums">[[${category.status.postCount +'篇'}]]</em>
+    <em class="post-nums" th:text="|${category.status.visiblePostCount ?: 0}篇|"></em>
   </th:block>
 </th:block>
 </html>


### PR DESCRIPTION
修复 /tags 页面中的文章数量显示问题。

before:

<img width="1014" alt="image" src="https://github.com/user-attachments/assets/96bfe2ca-08d4-411a-93d5-5b9b2431e830">

after:

<img width="1014" alt="image" src="https://github.com/user-attachments/assets/bf31f026-9f6a-418e-9041-623e9a1d2429">
 