### PR TITLE
规范日志页动画效果类名

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -2285,7 +2285,7 @@ spec:
           value: '暂无日志数据'
           help: '修改无数据时展示的文案'
         - $formkit: select
-          name: index_list_effect_class
+          name: journal_list_effect_class
           label: 动画效果类名
           value: 'fadeInUp'
           help: '日志页列表动画效果类名，来自 animate.css，默认 fadeInUp'

--- a/templates/modules/themeSettingVariable.html
+++ b/templates/modules/themeSettingVariable.html
@@ -71,7 +71,7 @@
         enable_journal_effect: /*[[${theme.config.journals.enable_journal_effect}]]*/ true,
         enable_friend_effect: /*[[${theme.config.friends.enable_friend_effect}]]*/ true,
         // prettier-ignore
-        journal_list_effect_class: /*[[${theme.config.journals.index_list_effect_class}]]*/ 'fadeInUp',
+        journal_list_effect_class: /*[[${theme.config.journals.journal_list_effect_class}]]*/ 'fadeInUp',
         friend_list_effect_class: /*[[${theme.config.friends.friend_list_effect_class}]]*/ 'fadeInUp',
         enable_like_journal: /*[[${theme.config.journals.enable_like_journal}]]*/ true,
         enable_comment_journal: /*[[${theme.config.journals.enable_comment_journal}]]*/ true,


### PR DESCRIPTION
将日志页动画效果类名index_list_effect_class改为journal_list_effect_class，前者应该为首页独称